### PR TITLE
rollback to pandas 1.5.3 (still upgrading from 1.3.5) and numpy 1.26.…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,8 @@ fuzzywuzzy[speedup]
 jellyfish
 networkx
 nltk
-pandas
+pandas==1.5.3
+numpy==1.26.4
 psycopg2-binary
 PyYAML
 rauth


### PR DESCRIPTION
…4 (still upgrading from 1.25.1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `pandas` dependency to a specific version `1.5.3` for improved stability.
	- Introduced a new dependency for `numpy` at version `1.26.4` to enhance compatibility and predictability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->