### PR TITLE
upgrade smart-open to last non-breaking change 1.10.0 => 4.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,12 +13,12 @@ nltk
 pandas==1.5.3
 numpy==1.26.4
 psycopg2-binary
-PyYAML
+pyyaml
 rauth
 redisearch
 scikit-learn[alldeps]
 simplejson
-smart-open==1.10.0
+smart-open==4.2.0
 sqlalchemy
 tslib
 typing


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the naming convention for the `PyYAML` package to `pyyaml`.
	- Upgraded the `smart-open` package from version `1.10.0` to `4.2.0`, potentially introducing new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->