### PR TITLE
Add pytest scaffolding and recipe tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,17 @@
+name: pytest
+
+on:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -128,3 +128,4 @@ If you want to contribute to the developpement, you'll be able to fork the repo 
 ```
 make start-dev
 ```
+\n### Running tests\nInstall development requirements and run pytest:\n```\npip install -r requirements.txt\npytest\n```

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ Werkzeug==3.0.3
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
 pyarrow>=14.0.1
+pytest

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -1,0 +1,45 @@
+import importlib.util
+from pathlib import Path
+import pytest
+
+pd = pytest.importorskip('pandas')
+np = pytest.importorskip('numpy')
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / 'code' / 'recipes.py'
+
+def load_recipes():
+    try:
+        spec = importlib.util.spec_from_file_location('recipes', MODULE_PATH)
+        recipes = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(recipes)
+        return recipes
+    except Exception as e:
+        pytest.skip(f'Could not import recipes module: {e}')
+
+recipes = load_recipes()
+
+
+def test_fwf_format_and_to_fwf(tmp_path):
+    df = pd.DataFrame({'A': ['a', 'bb'], 'B': ['1', '22']})
+    widths = [3, 3]
+    line = recipes.fwf_format(df.iloc[0], widths)
+    assert line == 'a  1  '
+    outfile = tmp_path / 'out.txt'
+    recipes.to_fwf(df, outfile, widths=widths, names=['A', 'B'])
+    content = outfile.read_text().splitlines()
+    assert content[0].strip() == line.strip()
+
+
+def test_internal_fillna_and_keep():
+    df = pd.DataFrame({'A': [1, None], 'B': [None, 'x']})
+    r_fill = recipes.Recipe.__new__(recipes.Recipe)
+    r_fill.args = [{'A': 0, 'B': ''}]
+    filled = recipes.Recipe.internal_fillna(r_fill, df.copy())
+    assert filled['A'].tolist() == [1, 0]
+    assert filled['B'].tolist() == ['', 'x']
+
+    r_keep = recipes.Recipe.__new__(recipes.Recipe)
+    r_keep.args = {'select': ['A']}
+    recipes.Recipe.select_columns(r_keep, filled)
+    kept = recipes.Recipe.internal_keep(r_keep, filled)
+    assert list(kept.columns) == ['A']


### PR DESCRIPTION
## Summary
- add basic pytest workflow
- add minimal tests for recipe helpers
- document running tests in README
- add pytest requirement

## Testing
- `pytest -q` *(fails: command not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automated running of Python tests on pull requests via GitHub Actions.
  - Added new tests to validate data formatting and processing functionality.

- **Documentation**
  - Updated README with instructions for installing dependencies and running tests.

- **Chores**
  - Added pytest to the list of development dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->