### PR TITLE
Kubernetes integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY requirements.txt .
 
 RUN apt-get update -y;\
     apt-get upgrade -y;\
-    apt-get install curl build-essential -y;\
+    apt-get install curl build-essential recode jq -y;\
     pip install --upgrade pip;\
     pip install `echo $http_proxy | sed 's/\(\S\S*\)/--proxy \1/'` -r requirements.txt;\
     apt-get autoremove build-essential -y;\

--- a/code/recipes.py
+++ b/code/recipes.py
@@ -196,8 +196,28 @@ class Connector(Configured):
                 self.scheme = self.conf["scheme"]
             except:
                 self.scheme = "http"
-            self.es = Elasticsearch(
-                self.host, port=self.port, scheme=self.scheme, timeout=self.timeout)
+
+            # Optional basic auth, only from env (ES_USER / ES_PWD)
+            es_user = os.getenv("ES_USER")
+            es_pwd = os.getenv("ES_PWD")
+
+            if es_user and es_pwd:
+                # Authenticated Elasticsearch client
+                self.es = Elasticsearch(
+                    self.host,
+                    port=self.port,
+                    scheme=self.scheme,
+                    timeout=self.timeout,
+                    http_auth=(es_user, es_pwd),
+                )
+            else:
+                # Backwards-compatible, no-auth client
+                self.es = Elasticsearch(
+                    self.host,
+                    port=self.port,
+                    scheme=self.scheme,
+                    timeout=self.timeout,
+                )
             try:
                 self.chunk_search = self.conf["chunk_search"]
             except:


### PR DESCRIPTION
This Pull Request permit to the backend to request Elasticsearch with authentication if asked by Elastic, but doesn't break the code if no user and password are given.

The second change is about Dockerfile, where we install recode and jq in the image, so we can run the datagouv-get-files script ( from tools repository ), without using another container.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Elasticsearch connections now support optional HTTP basic authentication configured via environment variables.

* **Chores**
  * Updated system dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->